### PR TITLE
fix: implement proper ping/pong correlation with timeout validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,6 @@ where
                         if let Err(e) = write_lock.send(Message::Ping(payload.into())).await {
                             return Err(anyhow!(ConnectionError::PingFailed(e.to_string())));
                         }
-                        debug!("Ping sent with timestamp payload");
                     }
                 }
                 sleep(Duration::from_secs(ping_duration_clone)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,7 @@ where
             loop {
                 {
                     let tracker = ping_tracker_clone.read().await;
-                    if let Err(e) = tracker.check_timeout() {
-                        return Err(e);
-                    }
+                    tracker.check_timeout()?;
 
                     if !tracker.should_send_ping() {
                         drop(tracker);
@@ -246,17 +244,13 @@ where
                                     }
                                 }
                                 Message::Pong(pong) => {
-                                    // Call user hook first
                                     if let Some(on_pong_func) = on_pong_clone.as_ref() {
                                         on_pong_func(pong.clone());
                                     }
 
-                                    // Validate pong against outstanding ping
                                     {
                                         let mut tracker = ping_tracker_clone.write().await;
-                                        if let Err(e) = tracker.handle_pong(pong.to_vec()) {
-                                            return Err(e);
-                                        }
+                                        tracker.handle_pong(pong.to_vec())?;
                                     }
                                 }
                                 Message::Close(maybe_frame) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ impl Connection<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
                 let read_loop = self.read_loop().await;
                 let ping_loop = self.ping_loop().await;
 
+                //Wait 500 for connection init
                 sleep(Duration::from_millis(500)).await;
                 for message in self.config.write_on_init.clone() {
                     let _ = self.write(message).await;


### PR DESCRIPTION
Fixes #5

Implemented Option 2 solution from the issue: single outstanding ping with payload validation.

## Changes
- Add SimplePingTracker struct for proper ping/pong correlation
- Replace global last_pong with payload-specific validation
- Add configurable ping_timeout instead of hardcoded +5s
- Use unique timestamp payloads per RFC 6455
- Prevent unsolicited pongs from affecting timeouts
- All tests pass

Generated with [Claude Code](https://claude.ai/code)