### PR TITLE
Fix .unwrap() calls that can panic in production

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kharbranth"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
Fixes #2

## Summary
- Replace all problematic .unwrap() calls with proper error handling
- Add descriptive error messages for connection stream access
- Fix system time arithmetic with proper error handling
- Fix URL parsing with context-aware error messages
- Replace silent error ignoring with proper logging
- Update function signatures to return Result types

## Test plan
- [x] Code compiles without errors or warnings
- [x] All 9 unit tests pass
- [x] Clippy linting passes with no warnings

Generated with [Claude Code](https://claude.ai/code)