### PR TITLE
Replace ReadHooks with Stream/Sink API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kharbranth"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 
 [lib]

--- a/src/bin/test-hyperliquid.rs
+++ b/src/bin/test-hyperliquid.rs
@@ -56,19 +56,25 @@ async fn main() -> Result<()> {
 
     // Spawn a task to handle incoming messages
     tokio::spawn(async move {
-        while let Some(message) = stream.next().await {
-            match message {
-                Message::Text(text) => {
-                    info!("Received text: {}", text);
-                }
-                Message::Binary(data) => {
-                    info!("Received binary data: {} bytes", data.len());
-                }
-                Message::Close(_) => {
-                    info!("Connection closed");
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(message) => match message {
+                    Message::Text(text) => {
+                        info!("Received text: {}", text);
+                    }
+                    Message::Binary(data) => {
+                        info!("Received binary data: {} bytes", data.len());
+                    }
+                    Message::Close(_) => {
+                        info!("Connection closed");
+                        break;
+                    }
+                    _ => {}
+                },
+                Err(e) => {
+                    info!("Stream error: {}", e);
                     break;
                 }
-                _ => {}
             }
         }
     });

--- a/src/bin/test-hyperliquid.rs
+++ b/src/bin/test-hyperliquid.rs
@@ -48,6 +48,8 @@ async fn main() -> Result<()> {
         ping_timeout: 30,
         reconnect_timeout: 5,
         write_on_init: vec![TungsteniteMessage::Text(subscribe_json.into())],
+        message_buffer_size: 1000,
+        write_buffer_size: 100,
     };
 
     manager.new_conn("hyperliquid", config).await;
@@ -83,7 +85,7 @@ async fn main() -> Result<()> {
 
     tokio::spawn(async move {
         loop {
-            sleep(Duration::from_secs(10)).await;
+            sleep(Duration::from_secs(30)).await;
             info!("Sending restart signal to hyperliquid connection");
             if let Err(e) = tx.send(kharbranth::BroadcastMessage {
                 target: "hyperliquid".to_string(),

--- a/src/bin/test-hyperliquid.rs
+++ b/src/bin/test-hyperliquid.rs
@@ -50,11 +50,8 @@ async fn main() -> Result<()> {
         write_on_init: vec![TungsteniteMessage::Text(subscribe_json.into())],
     };
 
-    // Use the new Stream/Sink API
     use futures_util::StreamExt;
     let (_sink, mut stream) = manager.connect_stream("hyperliquid", config).await?;
-
-    // Spawn a task to handle incoming messages
     tokio::spawn(async move {
         while let Some(result) = stream.next().await {
             match result {


### PR DESCRIPTION
## Summary
- Implements Option 2 from issue #3 to replace callback-based ReadHooks with modern Stream/Sink API
- Removes complex `Arc<Option<Box<dyn Fn>>>` wrappers in favor of async-native patterns
- Adds new `Message` enum and `WebSocketSink`/`WebSocketStream` wrappers
- Updates test binary to demonstrate new API usage
- Breaking change requiring version bump to 0.2.0

## Test plan
- [x] All existing tests pass with updated API
- [x] New tests for Message conversion functionality  
- [x] Stream/Sink API integration test added
- [x] Code compiles without warnings
- [x] Clippy passes without issues
- [x] Cargo fmt applied

🤖 Generated with [Claude Code](https://claude.ai/code)